### PR TITLE
[FEAT] GitHub Actions 설정에 다국어 지원 추가

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ jobs:
         uses: ./
         with:
           base_branch: main
+          language: ko  # Optional, defaults to English
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,10 @@ inputs:
   base_branch:
     description: "Base branch to compare current changes with (e.g., main, develop)"
     required: true
+  language:
+    description: "Language to use for the PR description (e.g., en, ko, zh). Optional, defaults to English."
+    required: false
+    default: "en"
 
 runs:
   using: "docker"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 TARGET_BRANCH=${INPUT_BASE_BRANCH}
+LANGUAGE=${INPUT_LANGUAGE}
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
 git config --global --add safe.directory /github/workspace
@@ -13,7 +14,7 @@ if [ -n "$EXISTING_PR" ]; then
   exit 0
 fi
 
-PR_JSON=$(cat code.diff | python3 /summarize_with_gpt.py "$OPENAI_API_KEY")
+PR_JSON=$(cat code.diff | python3 /summarize_with_gpt.py "$OPENAI_API_KEY" "$LANGUAGE")
 PR_TITLE=$(echo "$PR_JSON" | jq -r '.title')
 PR_BODY=$(echo "$PR_JSON" | jq -r '.body')
 

--- a/summarize_with_gpt.py
+++ b/summarize_with_gpt.py
@@ -8,10 +8,10 @@ from openai import OpenAI
 def generate_pr_description(diff, api_key, language):
     client = OpenAI(api_key=api_key)
     
-    system_prompt = """
+    system_prompt = f"""
     너는 코드 변경사항을 분석해서 명확하고 구조화된 PR(Pull Request) 제목과 본문을 만드는 전문가야.
     다음 규칙을 엄격하게 따라야 해:
-    1. 모든 응답의 언어는 반드시 {language}로 작성할 것
+    1. 모든 응답의 언어는 반드시 "{language}"로 작성할 것
     2. 반드시 '[TYPE] 설명' 형식의 제목 사용할 것 (TYPE은 FEAT, FIX, DOCS, STYLE, REFACTOR, TEST, BUILD, CI, CHORE, REVERT 중 하나)
     3. 반드시 완벽한 JSON 형식으로 응답할 것 (title과 body만 포함하는 단순 구조)
     
@@ -23,7 +23,7 @@ def generate_pr_description(diff, api_key, language):
     위는 코드의 변경 사항에 대한 Git diff야. diff를 보고 적절한 PR 제목과 본문을 만들어줘.
 
     ⚠️ 중요한 요구사항 ⚠️
-    1. 응답은 반드시 한국어로 작성해야 함
+    1. 응답은 반드시 {language} 언어로 작성해야 함
     2. 제목은 반드시 '[TYPE] 변경 사항 요약' 형식이어야 함
     3. 반드시 완벽한 JSON 형식으로 응답해야 함
 
@@ -67,8 +67,8 @@ def generate_pr_description(diff, api_key, language):
     }}
 
     마지막으로, 다음 세 가지는 절대 어기지 말아야 할 규칙이야:
-    1. 제목의 형식은 '[TYPE] 변경 사항 요약'이어야 함
-    2. 제목과 본문은 반드시 '{language}' 언어로 작성해야 함
+    1. 제목과 본문은 반드시 {language} 언어로 작성해야 함
+    2. 제목의 형식은 '[TYPE] 변경 사항 요약'이어야 함
     3. 응답 형식은 반드시 유효한 JSON이어야 함 (추가 문구 없이)
     """
     

--- a/summarize_with_gpt.py
+++ b/summarize_with_gpt.py
@@ -5,20 +5,13 @@ import sys
 from openai import OpenAI
 
 
-def generate_pr_description(diff, api_key):
-    # 테스트 모드 확인 (API 키가 'test_'로 시작하는 경우)
-    if api_key.startswith("test_"):
-        return {
-            "title": "[TEST] 테스트 PR 생성",
-            "body": "### ✅ 테스트\n- 이것은 테스트 PR 설명입니다.\n- 실제 API 호출 없이 생성되었습니다."
-        }
-    
+def generate_pr_description(diff, api_key, language):
     client = OpenAI(api_key=api_key)
     
     system_prompt = """
     너는 코드 변경사항을 분석해서 명확하고 구조화된 PR(Pull Request) 제목과 본문을 만드는 전문가야.
     다음 규칙을 엄격하게 따라야 해:
-    1. 모든 응답은 반드시 한국어로 작성할 것
+    1. 모든 응답의 언어는 반드시 {language}로 작성할 것
     2. 반드시 '[TYPE] 설명' 형식의 제목 사용할 것 (TYPE은 FEAT, FIX, DOCS, STYLE, REFACTOR, TEST, BUILD, CI, CHORE, REVERT 중 하나)
     3. 반드시 완벽한 JSON 형식으로 응답할 것 (title과 body만 포함하는 단순 구조)
     
@@ -75,7 +68,7 @@ def generate_pr_description(diff, api_key):
 
     마지막으로, 다음 세 가지는 절대 어기지 말아야 할 규칙이야:
     1. 제목의 형식은 '[TYPE] 변경 사항 요약'이어야 함
-    2. 제목과 본문은 반드시 '한국어'로 작성해야 함
+    2. 제목과 본문은 반드시 '{language}' 언어로 작성해야 함
     3. 응답 형식은 반드시 유효한 JSON이어야 함 (추가 문구 없이)
     """
     
@@ -105,12 +98,13 @@ if len(sys.argv) < 2:
     sys.exit(1)
 
 api_key = sys.argv[1]
+language = sys.argv[2]
 
 try:
     with open("code.diff", "r") as f:
         diff = f.read()
     
-    result = generate_pr_description(diff, api_key)
+    result = generate_pr_description(diff, api_key, language)
     print(json.dumps(result, ensure_ascii=False))
 except Exception as e:
     print(json.dumps({


### PR DESCRIPTION
이 PR은 아래의 변경 사항을 포함하고 있습니다.
### 🌐 다국어 지원 추가
- GitHub Actions의 workflow와 action 설정에 'language' 옵션을 추가하여, PR 제목과 본문을 다양한 언어로 생성할 수 있도록 지원합니다.
- 이 변경으로 사용자는 'ko', 'en', 'zh' 등 다양한 언어 옵션을 설정할 수 있습니다.

이 변경은 기존의 영어 기본 설정을 유지하면서 추가적인 언어 선택 옵션을 제공하여, 글로벌 사용자의 접근성을 향상시키기 위한 것입니다. 다양한 언어로의 PR 생성 지원을 통해 사용자 경험을 개선하고, 국제적인 프로젝트 관리가 보다 용이해질 것으로 기대됩니다.